### PR TITLE
Update character limit display to reflect 5000 chars

### DIFF
--- a/src/views/MessagesPage.vue
+++ b/src/views/MessagesPage.vue
@@ -94,7 +94,7 @@
       </div>
       <p class="text-xs">
         <span :class="message.length > 4999 ? 'text-harvard-red' : ''">{{ message.length }}</span
-        >/10000 character limit
+        >/5000 character limit
       </p>
     </div>
   </div>


### PR DESCRIPTION
Oops! This was still set to 10k from a previous trial.