### PR TITLE
Add robots file to public build

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,19 @@
+User-agent: *
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Googlebot
+Disallow: /
+
+User-agent: Bingbot
+Disallow: /
+
+Crawl-delay: 86400


### PR DESCRIPTION
Adds second layer of robots no-follow to app on top of the existing <meta> tag in the built index file of the front end.