### PR TITLE
Allow accessing polls pages with a shared link

### DIFF
--- a/src/plugins/navigationGuard.js
+++ b/src/plugins/navigationGuard.js
@@ -20,6 +20,14 @@ function isChannelsPage(to) {
   return to.name === 'home.channels' && to.params.channelId !== null
 }
 
+function isPollsPage(to) {
+  return (
+    ['home.polls', 'home.polls.results'].includes(to.name) &&
+    to.params.pollId !== null &&
+    to.params.channelId !== null
+  )
+}
+
 function isLoginSignupPage(to) {
   return ['home.login', 'home.createAccount'].includes(to.name)
 }
@@ -38,7 +46,8 @@ export default async (to, from, next) => {
   // Home page
   // Allow accessing the threads page with a shared link
   // Allow accessing the channels page with a shared link
-  else if (to.name === 'home.channelspage' || isThreadsPage(to) || isChannelsPage(to)) {
+  // Allow accessing the polls page with a shared link
+  else if (to.name === 'home.channelspage' || isThreadsPage(to) || isChannelsPage(to) || isPollsPage(to)) {
     await checkAndLoadNewPseudonym(next)
   }
 


### PR DESCRIPTION
Fixes #102.

First-time visitors clicking a shared poll link were redirected to the channel list: the navigation guard's shared-link branch covers threads and channels but not poll routes, so visitors without cookies fell through to the default redirect before a guest session existed. On a second visit the guest cookies exist, which is why reopening the link worked.

This adds an `isPollsPage` check (covering `home.polls` and `home.polls.results`) to the shared-link branch, mirroring `isThreadsPage` and `isChannelsPage`, so poll links get the same guest-session treatment.